### PR TITLE
タイムラプス表示後のカラーリングを修正

### DIFF
--- a/cli/timelapse.go
+++ b/cli/timelapse.go
@@ -28,10 +28,8 @@ func Timelapse(r render.Renderer, minutes, delay int, loop bool) error {
 	// まずクリアする
 	fmt.Printf("\033c")
 
-	// FIXME: カーソルを一番上に持っていく作業
 	var moveCursorToTop = func() {
-		height := 1000
-		fmt.Printf("\033[s\033[%dA\033[1;32m", height)
+		fmt.Print("\033[s\033[H\033[1;32m")
 	}
 
 	length := len(snapshots)
@@ -46,7 +44,7 @@ func Timelapse(r render.Renderer, minutes, delay int, loop bool) error {
 		time.Sleep(time.Duration(delay) * time.Millisecond)
 	}
 
-	// TODO: カラーリングをリセットする
+	fmt.Print("\033c")
 
 	return nil
 }

--- a/cli/timelapse.go
+++ b/cli/timelapse.go
@@ -44,7 +44,7 @@ func Timelapse(r render.Renderer, minutes, delay int, loop bool) error {
 		time.Sleep(time.Duration(delay) * time.Millisecond)
 	}
 
-	fmt.Print("\033c")
+	fmt.Print("\033[0m")
 
 	return nil
 }


### PR DESCRIPTION
**修正内容**
- カーソルを1,1に移動するエスケープコードを変更 (`CSI n ; m H`)
https://en.wikipedia.org/wiki/ANSI_escape_code#CSI_sequences

- タイムラプス終了後のカラーリングをリセット
